### PR TITLE
Introduce quickcheck testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bitintr = "0.1.*"
 
 [dev-dependencies]
 bencher = "0.1.*"
+quickcheck = "0.4.1"
 
 [[bench]]
 name = "morton"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ extern crate core as std;
 #[cfg(RUSTC_IS_NIGHTLY)]
 extern crate test;
 
+#[cfg(test)]
+extern crate quickcheck;
+
 /// Low-level bitwise manipulation intrinsics.
 pub extern crate bitintr;
 

--- a/src/word/is_aligned.rs
+++ b/src/word/is_aligned.rs
@@ -47,3 +47,44 @@ impl<T: Word> IsAligned for T {
         is_aligned(self, u)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use word::*;
+    use quickcheck::{TestResult, QuickCheck};
+
+    macro_rules! prop_is_aligned_tests {
+        ($($name:ident: ($WordType:ty, $UnsignedType:ty),)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    fn inner(x: $WordType, alignment: $UnsignedType) -> TestResult {
+                        if alignment < 1 {
+                            return TestResult::discard();
+                        }
+                        if !alignment.is_pow2() {
+                            return TestResult::discard();
+                        }
+
+                        let res = x.is_aligned(alignment);
+
+                        if x == 0 || (x % alignment) == 0 { // zero or multiple
+                            TestResult::from_bool(res)
+                        } else {
+                            TestResult::from_bool(!res)
+                        }
+                    }
+                    QuickCheck::new().quickcheck(inner as fn($WordType, $UnsignedType) -> TestResult);
+                }
+            )*
+        }
+    }
+
+    prop_is_aligned_tests! {
+        prop_is_aligned_u8_u8: (u8, u8),
+        prop_is_aligned_u16_u16: (u16, u16),
+        prop_is_aligned_u32_u32: (u32, u32),
+        prop_is_aligned_u64_u64: (u64, u64),
+        prop_is_aligned_usize_usize: (usize, usize),
+    }
+}

--- a/src/word/is_even.rs
+++ b/src/word/is_even.rs
@@ -30,3 +30,38 @@ impl<T: Word> IsEven for T {
         is_even(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use word::*;
+    use quickcheck::{TestResult, QuickCheck};
+
+    macro_rules! prop_is_even_tests {
+        ($($name:ident: $WordType:ty,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    fn inner(x: $WordType) -> TestResult {
+                        let rem = (x % 2) == 0;
+                        let res = x.is_even();
+                        TestResult::from_bool(rem == res)
+                    }
+                    QuickCheck::new().quickcheck(inner as fn($WordType) -> TestResult);
+                }
+            )*
+        }
+    }
+
+    prop_is_even_tests! {
+        prop_is_even_u8: u8,
+        prop_is_even_i8: i8,
+        prop_is_even_u16: u16,
+        prop_is_even_i16: i16,
+        prop_is_even_u32: u32,
+        prop_is_even_i32: i32,
+        prop_is_even_u64: u64,
+        prop_is_even_i64: i64,
+        prop_is_even_usize: usize,
+        prop_is_even_isize: isize,
+    }
+}

--- a/src/word/is_odd.rs
+++ b/src/word/is_odd.rs
@@ -30,3 +30,38 @@ impl<T: Word> IsOdd for T {
         is_odd(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use word::*;
+    use quickcheck::{TestResult, QuickCheck};
+
+    macro_rules! prop_is_odd_tests {
+        ($($name:ident: $WordType:ty,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    fn inner(x: $WordType) -> TestResult {
+                        let rem = (x % 2) != 0;
+                        let res = x.is_odd();
+                        TestResult::from_bool(rem == res)
+                    }
+                    QuickCheck::new().quickcheck(inner as fn($WordType) -> TestResult);
+                }
+            )*
+        }
+    }
+
+    prop_is_odd_tests! {
+        prop_is_odd_u8: u8,
+        prop_is_odd_i8: i8,
+        prop_is_odd_u16: u16,
+        prop_is_odd_i16: i16,
+        prop_is_odd_u32: u32,
+        prop_is_odd_i32: i32,
+        prop_is_odd_u64: u64,
+        prop_is_odd_i64: i64,
+        prop_is_odd_usize: usize,
+        prop_is_odd_isize: isize,
+    }
+}

--- a/src/word/is_pow2.rs
+++ b/src/word/is_pow2.rs
@@ -33,3 +33,49 @@ impl<T: Word> IsPow2 for T {
         is_pow2(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use word::*;
+    use quickcheck::{TestResult, QuickCheck};
+
+    macro_rules! prop_is_pow2_tests {
+        ($($name:ident: $WordType:ty,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    fn inner(x: $WordType) -> TestResult {
+                        if x <= 0 {
+                            return TestResult::discard();
+                        }
+
+                        // Determine if y is a power of two in the
+                        // keep-dividing-until-we-hit-the-floor method.
+                        let mut y = x;
+                        while ((y % 2) == 0) && y > 1 {
+                            y /= 2;
+                        }
+
+                        let rem = y == 1;
+                        let res = x.is_pow2();
+                        TestResult::from_bool(rem == res)
+                    }
+                    QuickCheck::new().quickcheck(inner as fn($WordType) -> TestResult);
+                }
+            )*
+        }
+    }
+
+    prop_is_pow2_tests! {
+        prop_is_pow2_u8: u8,
+        prop_is_pow2_i8: i8,
+        prop_is_pow2_u16: u16,
+        prop_is_pow2_i16: i16,
+        prop_is_pow2_u32: u32,
+        prop_is_pow2_i32: i32,
+        prop_is_pow2_u64: u64,
+        prop_is_pow2_i64: i64,
+        prop_is_pow2_usize: usize,
+        prop_is_pow2_isize: isize,
+    }
+}


### PR DESCRIPTION
This commit introduces the quickcheck library into the project, testing the word/is_* traits. Quickcheck is very helpful for finding edge-case bugs in complex algorithms -- of which the is_* are not -- so this commit exists as more of a demonstration of technique. Macros are used to generate test code over built-in integer types and slower but "obviously correct" algorithms are tested against the production quality code.

I'd like to use bitwise in a compact datastructure project which I expect to QC and fuzz like crazy. To that end I thought it wise to introduce QC'ing directly into bitwise and, if you're open to it, fuzzing as well via [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) in a latter commit. QC testing is less efficient at detecting bugs compared to exhaustive testing where exhaustive testing is applicable but _pretty good_ at searching the haystack in large domains like u64. This can be further improved with branch-directed fuzzing.

I'll add more QC tests over time. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>