### PR TITLE
Update to bitintr 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitwise"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 description = "Portable high-level bitwise manipulation algorithms."
 documentation = "https://gnzlbg.github.io/bitwise"
@@ -16,14 +16,14 @@ categories = ["algorithms", "hardware-support", "no-std"]
 travis-ci = { repository = "gnzlbg/bitwise", branch = "master" }
 
 [build-dependencies]
-rustc_version = "0.1.*"
+rustc_version = "0.2"
 
 [dependencies]
-bitintr = "0.1.*"
+bitintr = "0.2"
 
 [dev-dependencies]
-bencher = "0.1.*"
-quickcheck = "0.4.1"
+bencher = "0.1"
+quickcheck = "0.6"
 
 [[bench]]
 name = "morton"

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,10 @@ use rustc_version::{version, version_meta, Channel};
 
 fn main() {
     // Assert we haven't travelled back in time
-    assert!(version().major >= 1);
+    assert!(version().unwrap().major >= 1);
     
     // Set cfg flags depending on release channel
-    match version_meta().channel {
+    match version_meta().unwrap().channel {
         Channel::Nightly => {
             println!("cargo:rustc-cfg=RUSTC_IS_NIGHTLY");
         },

--- a/src/word/clear_bits_geq.rs
+++ b/src/word/clear_bits_geq.rs
@@ -1,5 +1,4 @@
 use word::{Word, ToWord, UnsignedWord};
-use bitintr;
 
 /// Clears all bits of `x` at position >= `bit`.
 ///
@@ -21,7 +20,7 @@ use bitintr;
 #[inline]
 pub fn clear_bits_geq<T: Word, U: UnsignedWord>(x: T, bit: U) -> T {
     debug_assert!(T::bit_size() > bit.to());
-    bitintr::x86::bmi2::bzhi(x, bit.to())
+    x.bzhi(bit.to())
 }
 
 /// Method version of [`clear_bits_geq`](fn.clear_bits_geq.html).

--- a/src/word/clear_least_significant_one.rs
+++ b/src/word/clear_least_significant_one.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Clear least significant set bit of `x`.
 ///
@@ -21,7 +20,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn clear_least_significant_one<T: Word>(x: T) -> T {
-    bitintr::x86::bmi::blsr(x) //x & (x - T::one())
+    x.blsr() //x & (x - T::one())
 }
 
 /// Method version of [`clear_least_significant_one`](fn.clear_least_significant_one.html).

--- a/src/word/clear_trailing_ones.rs
+++ b/src/word/clear_trailing_ones.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Clear the trailing bits set of `x`.
 ///
@@ -21,7 +20,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn clear_trailing_ones<T: Word>(x: T) -> T {
-    bitintr::x86::tbm::blcfill(x)
+    x.blcfill()
 }
 
 /// Method version of [`clear_trailing_ones`](fn.clear_trailing_ones.html).

--- a/src/word/count_leading_zeros.rs
+++ b/src/word/count_leading_zeros.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Counts the number of leading zeros in the binary representation of `x`.
 ///
@@ -26,7 +25,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn count_leading_zeros<T: Word>(x: T) -> T {
-    bitintr::x86::abm::lzcnt(x)
+    x.lzcnt()
 }
 
 /// Method version of [`count_leading_zeros`](fn.count_leading_zeros.html).

--- a/src/word/count_ones.rs
+++ b/src/word/count_ones.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr::x86::abm;
 
 /// Number of ones in the binary representation of `x`.
 ///
@@ -26,7 +25,7 @@ use bitintr::x86::abm;
 /// ```
 #[inline]
 pub fn count_ones<T: Word>(x: T) -> T {
-    abm::popcnt(x)
+    x.popcnt()
 }
 
 /// Method version of [`count_ones`](fn.count_ones.html).

--- a/src/word/count_trailing_zeros.rs
+++ b/src/word/count_trailing_zeros.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Count the number of trailing zeros in the binary representation of `x`.
 ///
@@ -23,7 +22,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn count_trailing_zeros<T: Word>(x: T) -> T {
-    bitintr::x86::bmi::tzcnt(x)
+    x.tzcnt()
 }
 
 /// Method version of [`count_trailing_zeros`](fn.count_trailing_zeros.html).

--- a/src/word/extract_bits.rs
+++ b/src/word/extract_bits.rs
@@ -1,5 +1,4 @@
 use word::{Word, ToWord};
-use bitintr;
 
 /// Extract bits [`start`, `start + length`) from `x` into the lower bits
 /// of the result.
@@ -22,7 +21,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn extract_bits<T: Word, U: Word>(x: T, start: U, length: U) -> T {
-    bitintr::x86::bmi::bextr(x, start.to(), length.to())
+    x.bextr(start.to(), length.to())
 }
 
 /// Method version of [`extract_bits`](fn.extract_bits.html).

--- a/src/word/hamming_distance.rs
+++ b/src/word/hamming_distance.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr::x86::abm;
 
 /// Hamming distance between the binary representation of `x` and `y`.
 ///
@@ -38,7 +37,7 @@ use bitintr::x86::abm;
 /// ```
 #[inline]
 pub fn hamming_distance<T: Word>(x: T, y: T) -> T {
-    abm::popcnt(x ^ y)
+    (x ^ y).popcnt()
 }
 
 /// Method version of [`hamming_distance`](fn.hamming_distance.html).

--- a/src/word/is_aligned.rs
+++ b/src/word/is_aligned.rs
@@ -85,6 +85,5 @@ mod tests {
         prop_is_aligned_u16_u16: (u16, u16),
         prop_is_aligned_u32_u32: (u32, u32),
         prop_is_aligned_u64_u64: (u64, u64),
-        prop_is_aligned_usize_usize: (usize, usize),
     }
 }

--- a/src/word/is_even.rs
+++ b/src/word/is_even.rs
@@ -61,7 +61,5 @@ mod tests {
         prop_is_even_i32: i32,
         prop_is_even_u64: u64,
         prop_is_even_i64: i64,
-        prop_is_even_usize: usize,
-        prop_is_even_isize: isize,
     }
 }

--- a/src/word/is_odd.rs
+++ b/src/word/is_odd.rs
@@ -61,7 +61,5 @@ mod tests {
         prop_is_odd_i32: i32,
         prop_is_odd_u64: u64,
         prop_is_odd_i64: i64,
-        prop_is_odd_usize: usize,
-        prop_is_odd_isize: isize,
     }
 }

--- a/src/word/is_pow2.rs
+++ b/src/word/is_pow2.rs
@@ -75,7 +75,5 @@ mod tests {
         prop_is_pow2_i32: i32,
         prop_is_pow2_u64: u64,
         prop_is_pow2_i64: i64,
-        prop_is_pow2_usize: usize,
-        prop_is_pow2_isize: isize,
     }
 }

--- a/src/word/isolate_least_significant_one.rs
+++ b/src/word/isolate_least_significant_one.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with the least significant set bit of `x` set to 1.
 ///
@@ -22,7 +21,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn isolate_least_significant_one<T: Word>(x: T) -> T {
-    bitintr::x86::bmi::blsi(x)
+    x.blsi()
 }
 
 /// Method version of [`isolate_least_significant_one`](fn.isolate_least_significant_one.html).

--- a/src/word/isolate_least_significant_zero.rs
+++ b/src/word/isolate_least_significant_zero.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with the least significant zero bit of `x` set to 1.
 ///
@@ -22,7 +21,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn isolate_least_significant_zero<T: Word>(x: T) -> T {
-    bitintr::x86::tbm::blcic(x)
+    x.blcic()
 }
 
 /// Method version of [`isolate_least_significant_zero`](fn.isolate_least_significant_zero.html).

--- a/src/word/mask_trailing_ones.rs
+++ b/src/word/mask_trailing_ones.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with the trailing 1's of `self` set.
 ///
@@ -18,7 +17,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn mask_trailing_ones<T: Word>(x: T) -> T {
-    !bitintr::x86::tbm::t1mskc(x)
+    !x.t1mskc()
 }
 
 /// Method version of [`mask_trailing_ones`](fn.mask_trailing_ones.html).

--- a/src/word/mask_trailing_ones_and_least_significant_zero.rs
+++ b/src/word/mask_trailing_ones_and_least_significant_zero.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with all trailing 1's of `x` and the least
 /// significant 0 bit set.
@@ -20,7 +19,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn mask_trailing_ones_and_least_significant_zero<T: Word>(x: T) -> T {
-    bitintr::x86::tbm::blcmsk(x)
+    x.blcmsk()
 }
 
 /// Method version of [`mask_trailing_zeros_and_least_significant_zero`](fn.mask_trailing_zeros_and_least_significant_zero.html).

--- a/src/word/mask_trailing_zeros.rs
+++ b/src/word/mask_trailing_zeros.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with the trailing 0's of `x` set.
 ///
@@ -18,7 +17,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn mask_trailing_zeros<T: Word>(x: T) -> T {
-    bitintr::x86::tbm::tzmsk(x)
+    x.tzmsk()
 }
 
 /// Method version of [`mask_trailing_zeros`](fn.mask_trailing_zeros.html).

--- a/src/word/mask_trailing_zeros_and_least_significant_one.rs
+++ b/src/word/mask_trailing_zeros_and_least_significant_one.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Returns mask with all of the trailing 0's of `x` and the least
 /// significant 1 bit set.
@@ -20,7 +19,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn mask_trailing_zeros_and_least_significant_one<T: Word>(x: T) -> T {
-    bitintr::x86::bmi::blsmsk(x)
+    x.blsmsk()
 }
 
 /// Method version of [`mask_trailing_zeros_and_least_significant_one`](fn.mask_trailing_zeros_and_least_significant_one.html).

--- a/src/word/mod.rs
+++ b/src/word/mod.rs
@@ -1,9 +1,9 @@
 //! Algorithms for single words (u8...u64).
 
+mod word;
+pub use self::word::*;
+
 mod to_word;
-
-pub use bitintr::Int as Word;
-
 pub use self::to_word::*;
 
 mod count_zeros;

--- a/src/word/morton.rs
+++ b/src/word/morton.rs
@@ -186,7 +186,7 @@ pub mod lut {
         let loops = MortonIndex::byte_size().to_u8();
         for i in 0..loops {
             let shift = (i * 8) + startshift;
-            let index: usize = ((v >> shift.to()) & mask.to()).to();
+            let index: usize = ((v >> shift.to()) & mask.to()).to_usize();
             let val = MortonIndex::from_u8(lut[index]);
             result = result | (val << (4 * i as u32).to()).to();
         }
@@ -232,7 +232,7 @@ pub mod lut {
         let loops = if loops >= 8 { 7 } else { loops };
         for i in 0..loops {
             let shift = (i * 9) + startshift;
-            let index: usize = ((v >> shift.to()) & mask).to();
+            let index: usize = ((v >> shift.to()) & mask).to_usize();
             let val = MortonIndex::from_u8(lut[index]);
             result = result | (val << (3 * i as u32).to()).to();
         }

--- a/src/word/parallel_bits_deposit.rs
+++ b/src/word/parallel_bits_deposit.rs
@@ -1,5 +1,4 @@
 use word::{Word, ToWord};
-use bitintr;
 
 /// Parallel bits deposit of `mask` into `x`.
 ///
@@ -28,7 +27,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn parallel_bits_deposit<T: Word, U: Word>(x: T, mask: U) -> T {
-    bitintr::x86::bmi2::pdep(x, mask.to())
+    x.pdep(mask.to())
 }
 
 /// Method version of [`parallel_bits_deposit`](fn.parallel_bits_deposit.html).

--- a/src/word/parallel_bits_extract.rs
+++ b/src/word/parallel_bits_extract.rs
@@ -1,5 +1,4 @@
 use word::{Word, ToWord};
-use bitintr;
 
 /// Parallel bits extract of `mask` from `x`.
 ///
@@ -28,7 +27,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn parallel_bits_extract<T: Word, U: Word>(x: T, mask: U) -> T {
-    bitintr::x86::bmi2::pext(x, mask.to())
+    x.pext(mask.to())
 }
 
 /// Method version of [`parallel_bits_extract`](fn.parallel_bits_extract.html).

--- a/src/word/reverse_bits.rs
+++ b/src/word/reverse_bits.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Reverses the bits of `x`.
 ///
@@ -16,7 +15,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn reverse_bits<T: Word>(x: T) -> T {
-    bitintr::arm::v7::rbit(x)
+    x.rbit()
 }
 
 /// Method version of [`reverse_bits`](fn.reverse_bits.html).

--- a/src/word/set_least_significant_zero.rs
+++ b/src/word/set_least_significant_zero.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr::x86::tbm;
 
 /// Set least significant 0 bit of `x`.
 ///
@@ -19,7 +18,7 @@ use bitintr::x86::tbm;
 /// ```
 #[inline]
 pub fn set_least_significant_zero<T: Word>(x: T) -> T {
-    tbm::blcs(x)
+    x.blcs()
 }
 
 /// Method version of [`set_least_significant_zero`](fn.set_least_significant_zero.html).

--- a/src/word/set_trailing_zeros.rs
+++ b/src/word/set_trailing_zeros.rs
@@ -1,5 +1,4 @@
 use word::Word;
-use bitintr;
 
 /// Set the trailing 0's of `x`.
 ///
@@ -21,7 +20,7 @@ use bitintr;
 /// ```
 #[inline]
 pub fn set_trailing_zeros<T: Word>(x: T) -> T {
-    bitintr::x86::tbm::blsfill(x)
+    x.blsfill()
 }
 
 /// Method version of [`set_trailing_zeros`](fn.set_trailing_zeros.html).

--- a/src/word/to_word.rs
+++ b/src/word/to_word.rs
@@ -6,7 +6,6 @@ impl UnsignedWord for u8 {}
 impl UnsignedWord for u16 {}
 impl UnsignedWord for u32 {}
 impl UnsignedWord for u64 {}
-impl UnsignedWord for usize {}
 
 /// From-like trait for words.
 pub trait FromWord<T> {
@@ -37,8 +36,8 @@ macro_rules! impl_from_word_multiple {
 
 macro_rules! impl_from_word {
     ($From:ty) => (
-        impl_from_word_multiple!($From, i8, i16, i32, i64, isize,
-                                 u8, u16, u32, u64, usize);
+        impl_from_word_multiple!($From, i8, i16, i32, i64,
+                                 u8, u16, u32, u64);
     )
 }
 
@@ -46,12 +45,10 @@ impl_from_word!(i8);
 impl_from_word!(i16);
 impl_from_word!(i32);
 impl_from_word!(i64);
-impl_from_word!(isize);
 impl_from_word!(u8);
 impl_from_word!(u16);
 impl_from_word!(u32);
 impl_from_word!(u64);
-impl_from_word!(usize);
 
 impl<T: Word, U: Word> FromWord<T> for U {
     #[inline]

--- a/src/word/word.rs
+++ b/src/word/word.rs
@@ -1,0 +1,206 @@
+//! Generic Integer traits.
+
+use std::ops::{Add, Sub, Mul, Div, Rem};
+use std::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
+use std::cmp::{PartialEq, PartialOrd};
+use std::mem::size_of;
+
+use bitintr::*;
+
+/// Integer trait used to parametrize algorithms for all integer types.
+pub trait Word
+    : Sized
+    + Copy
+    + Add<Output=Self>
+    + Sub<Output=Self>
+    + Mul<Output=Self>
+    + Div<Output=Self>
+    + Rem<Output=Self>
+    + Not<Output=Self>
+    + BitAnd<Output=Self>
+    + BitOr<Output=Self>
+    + BitXor<Output=Self>
+    + Shr<Self, Output=Self>
+    + Shl<Self, Output=Self>
+    + PartialEq + PartialOrd
+    + Bzhi
+    + Blsr
+    + Blcfill
+    + Lzcnt
+    + Popcnt
+    + Tzcnt
+    + Bextr
+    + Popcnt
+    + Blsi
+    + Blcic
+    + Blcmsk
+    + T1mskc
+    + Blsmsk
+    + Tzmsk
+    + Pdep
+    + Pext
+    + Rbit
+    + Blcs
+    + Blsfill
+{
+    type Unsigned: Word;
+    type Signed: Word;
+    #[inline] fn one() -> Self;
+    #[inline] fn zero() -> Self;
+    #[inline] fn byte_size() -> Self;
+    #[inline] fn bit_size() -> Self;
+    #[inline] fn count_ones(self) -> Self;
+    #[inline] fn count_zeros(self) -> Self;
+    #[inline] fn leading_zeros(self) -> Self;
+    #[inline] fn trailing_zeros(self) -> Self;
+    #[inline] fn wrapping_neg(self) -> Self;
+    #[inline] fn wrapping_add(self, Self) -> Self;
+    #[inline] fn wrapping_sub(self, Self) -> Self;
+    #[inline] fn wrapping_shl(self, Self) -> Self;
+    #[inline] fn wrapping_shr(self, Self) -> Self;
+    #[inline] fn to_u8(self) -> u8;
+    #[inline] fn to_u16(self) -> u16;
+    #[inline] fn to_u32(self) -> u32;
+    #[inline] fn to_u64(self) -> u64;
+    #[inline] fn to_i8(self) -> i8;
+    #[inline] fn to_i16(self) -> i16;
+    #[inline] fn to_i32(self) -> i32;
+    #[inline] fn to_i64(self) -> i64;
+    #[inline] fn from_u8(u8) -> Self;
+    #[inline] fn from_u16(u16) -> Self;
+    #[inline] fn from_u32(u32) -> Self;
+    #[inline] fn from_u64(u64) -> Self;
+    #[inline] fn from_i8(i8) -> Self;
+    #[inline] fn from_i16(i16) -> Self;
+    #[inline] fn from_i32(i32) -> Self;
+    #[inline] fn from_i64(i64) -> Self;
+    #[inline] fn rotate_left(self, u32) -> Self;
+    #[inline] fn rotate_right(self, u32) -> Self;
+    #[inline] fn swap_bytes(self) -> Self;
+    #[inline] fn from_be(self) -> Self;
+    #[inline] fn from_le(self) -> Self;
+    #[inline] fn to_be(self) -> Self;
+    #[inline] fn to_le(self) -> Self;
+    #[inline] fn pow(self, exp: u32) -> Self;
+    #[inline] fn to_unsigned(self) -> Self::Unsigned;
+    #[inline] fn to_signed(self) -> Self::Signed;
+    #[inline] fn from_unsigned(Self::Unsigned) -> Self;
+    #[inline] fn from_signed(Self::Signed) -> Self;
+    #[inline] fn to_usize(self) -> usize;
+}
+
+macro_rules! int_impl {
+    ($T:ty, $UT:ty, $ST:ty) => (
+        impl Word for $T {
+            type Unsigned = $UT;
+            type Signed = $ST;
+            #[inline] fn one() -> Self { 1 as Self }
+            #[inline] fn zero() -> Self { 0 as Self }
+
+            #[inline] fn byte_size() -> Self {
+                size_of::<Self>() as Self
+            }
+
+            #[inline] fn bit_size() -> Self {
+                (Self::byte_size() * 8) as Self
+            }
+
+            #[inline] fn count_ones(self) -> $T {
+                self.count_ones() as $T
+            }
+            #[inline] fn count_zeros(self) -> $T {
+                self.count_zeros() as $T
+            }
+            #[inline] fn leading_zeros(self) -> $T {
+                self.leading_zeros() as $T
+            }
+            #[inline] fn trailing_zeros(self) -> $T {
+                self.trailing_zeros() as $T
+            }
+            #[inline] fn wrapping_neg(self) -> $T {
+                self.wrapping_neg() as $T
+            }
+            #[inline] fn wrapping_add(self, o: Self) -> $T {
+                self.wrapping_add(o) as $T
+            }
+            #[inline] fn wrapping_sub(self, o: Self) -> $T {
+                self.wrapping_sub(o) as $T
+            }
+            #[inline] fn wrapping_shl(self, o: Self) -> $T {
+                self.wrapping_shl(o as u32) as $T
+            }
+            #[inline] fn wrapping_shr(self, o: Self) -> $T {
+                self.wrapping_shr(o as u32) as $T
+            }
+
+            #[inline] fn to_u8(self) -> u8 { self as u8 }
+            #[inline] fn to_u16(self) -> u16 { self as u16 }
+            #[inline] fn to_u32(self) -> u32 { self as u32 }
+            #[inline] fn to_u64(self) -> u64 { self as u64 }
+            #[inline] fn to_i8(self) -> i8 { self as i8 }
+            #[inline] fn to_i16(self) -> i16 { self as i16 }
+            #[inline] fn to_i32(self) -> i32 { self as i32 }
+            #[inline] fn to_i64(self) -> i64 { self as i64 }
+            #[inline] fn from_u8(x: u8) -> Self { x as Self }
+            #[inline] fn from_u16(x: u16) -> Self { x as Self }
+            #[inline] fn from_u32(x: u32) -> Self { x as Self }
+            #[inline] fn from_u64(x: u64) -> Self { x as Self }
+            #[inline] fn from_i8(x: i8) -> Self { x as Self }
+            #[inline] fn from_i16(x: i16) -> Self { x as Self }
+            #[inline] fn from_i32(x: i32) -> Self { x as Self }
+            #[inline] fn from_i64(x: i64) -> Self { x as Self }
+
+            #[inline] fn rotate_left(self, n: u32) -> Self { (self as $T).rotate_left(n) }
+            #[inline] fn rotate_right(self, n: u32) -> Self { (self as $T).rotate_right(n) }
+            #[inline] fn swap_bytes(self) -> Self { <$T>::swap_bytes(self) }
+
+            #[inline] fn from_be(self) -> Self {
+                <$T>::from_be(self)
+            }
+
+            #[inline] fn from_le(self) -> Self {
+                <$T>::from_le(self)
+            }
+
+            #[inline] fn to_be(self) -> Self {
+                <$T>::to_be(self)
+            }
+
+            #[inline] fn to_le(self) -> Self {
+                <$T>::to_le(self)
+            }
+
+            #[inline] fn pow(self, exp: u32) -> Self {
+                <$T>::pow(self, exp)
+            }
+
+            #[inline] fn to_unsigned(self) -> Self::Unsigned {
+                self as $UT
+            }
+            #[inline] fn to_signed(self) -> Self::Signed {
+                self as $ST
+            }
+            #[inline] fn from_unsigned(x: Self::Unsigned) -> Self {
+                x as $T
+            }
+            #[inline] fn from_signed(x: Self::Signed) -> Self {
+                x as $T
+            }
+
+            #[inline] fn to_usize(self) -> usize {
+                self as usize
+            }
+        }
+    )
+}
+
+
+int_impl!(u8, u8, i8);
+int_impl!(u16, u16, i16);
+int_impl!(u32, u32, i32);
+int_impl!(u64, u64, i64);
+
+int_impl!(i8, u8, i8);
+int_impl!(i16, u16, i16);
+int_impl!(i32, u32, i32);
+int_impl!(i64, u64, i64);


### PR DESCRIPTION
This just updates to bitintr 0.2, I had to recreate the trait that was used, but that's the only big change, just a lot of renaming otherwise.
Not sure if this is really needed as I'm not sure whether there are any functional differences between bitintr 0.1 and 0.2, but thought I'd send across a pull request anyway.