### PR TITLE
Fix gnzlbg/bitwise#24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "gnzlbg/bitwise", branch = "master" }
 rustc_version = "0.2"
 
 [dependencies]
-bitintr = "0.2"
+bitintr = "0.3"
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
Fix gnzlbg/bitwise#24 by upgrading bitintr to version 0.3 as @apps4uco  suggested.